### PR TITLE
Fix broken delete/update methods

### DIFF
--- a/src/js/controllers/editor.js
+++ b/src/js/controllers/editor.js
@@ -198,6 +198,7 @@ GeotriggerEditor.module('Editor', function(Editor, App, Backbone, Marionette, $,
       });
       var model = App.collections.triggers.findWhere({'triggerId':triggerData.triggerId});
       model.set(triggerData);
+      model.set('id', model.get('triggerId')); // hack to ensure proper method
       model.save();
     },
 
@@ -207,6 +208,7 @@ GeotriggerEditor.module('Editor', function(Editor, App, Backbone, Marionette, $,
           App.router.navigate('list', { trigger: true });
         }
       });
+      model.set('id', model.get('triggerId')); // hack to ensure proper method
       model.destroy();
     }
   });


### PR DESCRIPTION
Backbone is very insistent on doing things the RESTful way -- I had to sidestep setting the `idAttribute` for triggers to allow a model to be created with a custom ID. This broke the delete method, as Backbone treats the model as new since it doesn't have a backbone-specific `id` attribute set, and so a `DELETE` call is never made to the server. The update method still worked but was misidentified on the client-side as a create event. This pull request introduces a one-line hack for both methods to ensure they do their job correctly.
