### PR TITLE
Fix duplicate trigggers in list after trigger/create overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * change image folder from `img/icons` to `img/geotrigger-editor` to avoid conflicts
 * move namespace to `Geotrigger.Editor` ([#185](https://github.com/Esri/geotrigger-editor/issues/185))
 * add support for `properties`, `rateLimit`, and `times` trigger parameters ([#192](https://github.com/Esri/geotrigger-editor/issues/192) & [#193](https://github.com/Esri/geotrigger-editor/issues/193))
+* fix for duplicate triggers appearing in list on trigger/create overwrite ([#189](https://github.com/Esri/geotrigger-editor/issues/189) & [#194](https://github.com/Esri/geotrigger-editor/issues/194))
 
 ## v0.1.3
 * fix CSS issue causing IDs not to display in title area on edit ([#186](https://github.com/Esri/geotrigger-editor/issues/186))

--- a/src/js/views/form.js
+++ b/src/js/views/form.js
@@ -487,15 +487,30 @@ Geotrigger.Editor.module('Views', function (Views, App, Backbone, Marionette, $,
     },
 
     createOrUpdateTrigger: function (data) {
+      var model = App.collections.triggers.findWhere({
+        'triggerId': data.triggerId
+      });
+
+      var isNew = !this.model && !model;
+      var isOverwrite = !this.model && !!model;
+      var isUpdate = !!this.model;
+
+      var warning = 'A trigger with the ID "' + data.triggerId + '" already exists. Do you want to overwrite it?';
+
       // create new trigger
-      if (!this.model) {
-        App.vent.trigger('trigger:create', data);
+      if (isNew) {
+        return App.vent.trigger('trigger:create', data);
+      }
+
+      // overwrite existing trigger (trigger/create dedupe workaround)
+      if (isOverwrite && confirm(warning)) {
+        return App.vent.trigger('trigger:update', data);
       }
 
       // update existing trigger
-      else {
+      if (isUpdate) {
         data.triggerId = this.model.get('triggerId');
-        App.vent.trigger('trigger:update', data);
+        return App.vent.trigger('trigger:update', data);
       }
     },
 


### PR DESCRIPTION
Users will be presented with a confirmation dialog if they try to create a new trigger with a custom ID that already exists for another trigger. If they confirm, the new trigger will overwrite the previous one.
- resolves #189 
- resolves #194 
