### PR TITLE
re-add support for a proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Icon
 
 # Node
 node_modules
+npm-debug.log
 
 # Ruby
 *.gem

--- a/README.md
+++ b/README.md
@@ -131,11 +131,7 @@ To run the development environment, you will need the following:
 1. [Grunt](http://gruntjs.com/)
 1. [Ruby](https://www.ruby-lang.org/en/downloads/) and [Compass](http://compass-style.org/install/) (to compile SASS)
 
-To install `node` on your system follow [these instructions](https://github.com/joyent/node/wiki/Installation#installing-without-building).
-
-*Note: if you're a mac developer we recommend using homebrew to `brew install node`.*
-
-Once Node.js is installed, you can install the Grunt command line interface by running `npm install -g grunt-cli`. This will install the grunt-cli package locally ([reference](https://npmjs.org/doc/install.html)).
+Once [Node.js](https://nodejs.org/en/download/) is installed, you can install the Grunt command line interface by running `npm install -g grunt-cli`. This will install the grunt-cli package locally ([reference](https://npmjs.org/doc/install.html)).
 
 #### Local Setup
 

--- a/examples/proxy/.gitignore
+++ b/examples/proxy/.gitignore
@@ -1,0 +1,1 @@
+npm-debug.log

--- a/examples/proxy/index.html
+++ b/examples/proxy/index.html
@@ -61,7 +61,7 @@
           session: {
             clientId: $('#client-id').val(),
             clientSecret: $('#client-secret').val(),
-            proxy: '/proxy/'
+            proxy: 'proxy/'
           }
         };
 

--- a/examples/proxy/package.json
+++ b/examples/proxy/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Esri Portland R&D Center <portland@esri.com>",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "request": "~2.27.0",
     "metaserve": "~0.1.0"

--- a/examples/proxy/proxy.js
+++ b/examples/proxy/proxy.js
@@ -22,7 +22,7 @@ function proxy (req, res) {
 
   var test = {
     proxy: /^\/proxy\/(.+)$/,
-    hosts: /^https?:\/\/(geotrigger\.)?arcgis\.com\//
+    hosts: /^https?:\/\/((geotrigger|www)\.)?arcgis\.com\//
   };
 
   var matchProxy = url.match(test.proxy);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "request": "~2.27.0",
     "grunt-rename": "~0.1.3",
     "grunt-jsbeautifier": "~0.2.6",
-    "geotrigger-js": "~1.0.1"
+    "geotrigger-js": "~1.0.4"
 
   },
   "author": "Esri Portland R&D Center <portland@esri.com>",

--- a/src/js/controllers/map.js
+++ b/src/js/controllers/map.js
@@ -8,11 +8,9 @@ Geotrigger.Editor.module('Map', function (Map, App, Backbone, Marionette, $, _) 
   _.extend(Map, {
 
     _setup: function (options) {
-      // L.Icon.Default.imagePath = App.config.imagePath;
-
       // force L.esri to use JSONP if proxy is set
       if (App.config.session.proxy) {
-        L.esri.get = L.esri.RequestHandlers.JSONP;
+        L.esri.get = L.esri.Request.get.JSONP;
       }
 
       var basemap = this._getDefaultBasemap();


### PR DESCRIPTION
* refactored the code to support proxies *selectively* at version `1.0.1` of esri leaflet.
* ~~ensured that `examples/` samples are pointing at the `tmp` build folder to take advantage of automatic rebuild~~
* ~~bumped tag to `0.2.2dev` (seems like it'd be worth tagging a release before pushing to the live developers site.~~
* got rid of an `npm install` nag

to do:
~~- [ ] figure out how to run `node /examples/proxy/proxy.js` and `grunt dev` concurrently on port '8080'~~ decided not to bother

ready for review @kneemer @paulcpederson 