### PR TITLE
trap failure to initialize session

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,7 +234,9 @@
   <form id="example">
     <h2>Geotrigger Editor</h2>
 
-    <p>The Geotrigger Editor is a visual editor for ArcGIS Geotrigger Service applications. Using only your Client ID and Secret (acquired from developers.arcgis.com) you too can visually edit your Geotrigger Service applications!</p>
+    <p>Please review the announcement below regarding the status of Esri's Geotrigger Service.</p>
+
+    <p><a href='https://developers.arcgis.com/geotrigger-service/'>https://developers.arcgis.com/geotrigger-service/</a></p>
 
     <p class="cors-warning hide">This application requires a browser with <a href="http://caniuse.com/cors">CORS</a> support. If you want to use the editor, you can either view this site with a newer browser or host the application yourself using a <a href="https://github.com/Esri/geofaker-js#browser">proxy</a>.
 
@@ -244,6 +246,9 @@
       <button class="engage-btn">Engage</button>
       <a class="what" href="https://developers.arcgis.com/en/geotrigger-service/guide/geotrigger-editor/">What's This?</a>
     </div>
+
+    <br>
+    <p>The Geotrigger Editor is a visual editor for ArcGIS Geotrigger Service applications. Using only your Client ID and Secret (acquired from developers.arcgis.com) you too can visually edit your Geotrigger Service applications!</p>
 
     <ul>
       <li>

--- a/src/js/controllers/editor.js
+++ b/src/js/controllers/editor.js
@@ -53,18 +53,25 @@ Geotrigger.Editor.module('Editor', function (Editor, App, Backbone, Marionette, 
         reset: true,
         success: function (model, response, options) {
           App.vent.trigger('notify:clear');
-
-          compabilityCheck();
-
-          // don't start history until triggers have been fetched
-          Backbone.history.start();
-
-          if (response && response.length === 0) {
-            App.router.navigate('list', {
-              trigger: true
+          if (!response) {
+            App.vent.trigger('notify', {
+             type: 'error',
+              message: 'Unable to start session.'
             });
-          } else if (App.config.fitOnLoad && !Backbone.history.fragment.match('edit')) {
-            App.execute('map:fit');
+          }
+          else {
+            compabilityCheck();
+
+            // don't start history until triggers have been fetched
+            Backbone.history.start();
+
+            if (response && response.length === 0) {
+              App.router.navigate('list', {
+                trigger: true
+              });
+            } else if (App.config.fitOnLoad && !Backbone.history.fragment.match('edit')) {
+              App.execute('map:fit');
+            }
           }
         }
       });

--- a/src/js/models/trigger.js
+++ b/src/js/models/trigger.js
@@ -137,7 +137,6 @@ Geotrigger.Editor.module('Models', function (Models, App, Backbone, Marionette, 
         } else {
           this.set(this.parse(response));
         }
-
         if (options && options.success) {
           options.success(this, this.parse(response), options);
         }
@@ -147,7 +146,10 @@ Geotrigger.Editor.module('Models', function (Models, App, Backbone, Marionette, 
     },
 
     parse: function (response) {
-      return response.triggers;
+      if (response) {
+        return response.triggers;
+      }
+      // return response.triggers;
     }
   });
 


### PR DESCRIPTION
resolves #231 

right now, for new ArcGIS Online applications, the server returns malformed JSON when a list of triggers is requested

POST https://geotrigger.arcgis.com/trigger/list {token: '...'}

``` json
{ 
  "error": {
    "type":  "invalidHeader",
    "message": "invalid header or header value",
    "headers": {
      "Authorization":[
        {
          "type":"invalid",
          "message":"Application creation is disabled"
        }
      ]
    },
    "code":400
  }
```

this patch is kind of ugly, but it traps the error, notifies the user and avoids an endless loop of requests.

currently requires the following tweak to geotrigger-js

``` js
// callback for handling a successful request
var handleSuccessfulResponse = function(){
  try {
    if (httpRequest.responseText.indexOf('Application creation is disabled') > -1) {
      error = {
        type: "unexpected_response",
        message: "Application creation is disabled"
      };
    } else {
      json = JSON.parse(httpRequest.responseText);
      response = (json.error) ? null : json;
      error = (json.error) ? json.error : null;
    }
```
